### PR TITLE
Switch to new PolyML FFI

### DIFF
--- a/src/Net/SSLSocket_polyml.sml
+++ b/src/Net/SSLSocket_polyml.sml
@@ -1,20 +1,34 @@
+(* This is not thread-safe. See Isabelle/HOL's implementation of with_memory for details. *)
+datatype 'a Exn = Value of 'a | Exn of exn;
+
+fun withMemory (n: int) f =
+    let
+        val mem = Foreign.Memory.malloc (Word.fromInt n);
+        val res = Value (f mem) handle (res) => (Exn res);
+        val _ = Foreign.Memory.free (mem);
+     in
+         case res of
+             Exn exn => raise (exn)
+           | Value v => v
+     end
+
 structure Ponyo_Net_SSLSocket : PONYO_NET_SOCKET =
 struct
     local
-        open CInterface
-        val get = get_sym (PONYO_ROOT ^ "/ssl.so");
+        val library = Foreign.loadLibrary (PONYO_ROOT ^ "/ssl.so");
+        val get = Foreign.getSymbol library;
     in
 
     val bufferSize = 4096
 
-    type sslSocket = vol
+    type sslSocket = Foreign.Memory.voidStar
     type ('a, 'b) t = sslSocket * ('a, 'b) Socket.sock
 
     fun connect (domain: string, port: int) : (INetSock.inet, Socket.active Socket.stream) t =
         let
             fun socketToInt s =
                 SysWord.toInt (Posix.FileSys.fdToWord (valOf (Posix.FileSys.iodToFD (Socket.ioDesc s))))
-            val sslWrap = call1 (get "ssl_wrap") INT POINTER;
+            val sslWrap = Foreign.buildCall1 (get "ssl_wrap", Foreign.cInt, Foreign.cPointer);
             val socket = Ponyo_Net_Socket.connect (domain, port);
         in
             (sslWrap (socketToInt socket): sslSocket, socket: (INetSock.inet, Socket.active Socket.stream) Socket.sock)
@@ -22,27 +36,39 @@ struct
 
     fun close (sslSocket: sslSocket, socket: ('a, 'b) Socket.sock) : unit =
         let
-            val sslClose = call1 (get "ssl_close") POINTER VOID;
+            val sslClose = Foreign.buildCall1 (get "ssl_close", Foreign.cPointer, Foreign.cVoid);
         in
             sslClose (sslSocket);
             Ponyo_Net_Socket.close (socket)
         end
 
     fun read (socket: sslSocket, _: ('a, Socket.active Socket.stream) Socket.sock) : Word8Vector.vector =
-        let
-            val buf = alloc bufferSize Cchar;
-            fun readBuf buf 0 = []
-              | readBuf buf n = fromCchar buf :: readBuf (offset 1 Cchar buf) (n - 1) 
-            
-            val numRead = call3 (get "ssl_read") (POINTER, POINTER, INT) INT (socket, address buf, bufferSize);
-        in
-            if numRead <= 0
-                then Byte.stringToBytes ""
-            else Byte.stringToBytes (CharVector.fromList (readBuf buf numRead))
-        end
+        withMemory bufferSize (fn mem =>
+            let
+                fun readBuf buf 0 = []
+                  | readBuf buf n = Foreign.Memory.get8 (buf, Word.fromInt 0) :: readBuf (Foreign.Memory.++ (buf: Foreign.Memory.voidStar, Word.fromInt 1)) (n - 1) 
+
+                val symbol = get ("ssl_read")
+                val argTypes = (Foreign.cPointer, Foreign.cPointer, Foreign.cInt)
+                val retType = Foreign.cInt
+                val f = Foreign.buildCall3 (symbol, argTypes, retType)
+                val numRead = f (socket, mem, bufferSize);
+            in
+                if numRead <= 0
+                    then Byte.stringToBytes ""
+                else
+                    Word8Vector.fromList (readBuf mem numRead)
+            end)
 
     fun write ((socket: sslSocket, _: ('a, Socket.active Socket.stream) Socket.sock), toWrite: Word8VectorSlice.slice) : int =
-        call3 (get "ssl_write") (POINTER, STRING, INT) INT (socket, Byte.unpackStringVec toWrite, Word8VectorSlice.length toWrite)
+        let
+            val symbol = get ("ssl_write")
+            val argTypes = (Foreign.cPointer, Foreign.cString, Foreign.cInt)
+            val retType = Foreign.cInt
+            val f = Foreign.buildCall3 (symbol, argTypes, retType)
+        in
+            f (socket, Byte.unpackStringVec toWrite, Word8VectorSlice.length toWrite)
+        end
 
     fun writeAll (socket: ('a, Socket.active Socket.stream) t, toWrite: Word8Vector.vector) : unit =
         let


### PR DESCRIPTION
Poly/ML recently dropped the FFI Ponyo was previously using and Ponyo stopped building. This gets Ponyo building again, but the SSL bindings are useless (and happen to not work either).