### PR TITLE
Do not raise an exception when URL ends with "/"

### DIFF
--- a/src/Net/Http/Client.sml
+++ b/src/Net/Http/Client.sml
@@ -22,9 +22,11 @@ struct
             val address = if String.hasSubstring (address, "://")
                 then (List.nth (String.split (address, "://"), 1))
                 else address
-            val (domain, path) = case String.splitN (address, "/", 1) of
-                [domain, path] => (domain, "/" ^ path)
-              | _ => raise InvalidRequestAddress (address)
+            val (domain, path) = Substring.splitl (fn c => c <> #"/") (Substring.full address)
+            val domain = Substring.string domain
+            val path = if Substring.isEmpty path
+                then "/"
+                else Substring.string path
             val request = case request' of
                 SOME request => request
               | _ => Request.init (Headers.new ()) ""


### PR DESCRIPTION
Ponyo_Net_Http.Client raises `InvalidRequestAddress` when URL ends with "/", such as "http://www.google.com/", which I believe is a valid address:

    Client.get ("http://www.google.com/", NONE)

It seems like `String.splitN (address, "/", 1)` does not return a two-element list; either `String.splitN` or `Client.go` is wrong. I rewrote the code with `Substring.splitl`, since the spec is clearer.

Note that my rewrite is more permissive than the oiginal; if there is no slash in the address, the path will be "/", instead of raising an exception.