### PR TITLE
MalformedResponse when reason phrase contains spaces

### DIFF
--- a/src/Net/Http/Response.sml
+++ b/src/Net/Http/Response.sml
@@ -63,17 +63,16 @@ struct
     val GatewayTimeout = makeGenericResponse 504 "Gateway Timeout"
 
     fun parseFirstLine (line: string) (response: Connection.t) : t =
-        case String.split (line, " ") of
-            [] =>  raise MalformedResponse (line)
-          | list => if length (list) <> 3
-              then raise MalformedResponse (line)
-              else {
-                  version = List.nth (list, 0),
-                  status  = valOf (Int.fromString (List.nth (list, 1))),
-                  reason  = List.nth (list, 2),
+        case String.splitN (line, " ", 2) of
+            [version, status, reason] =>
+              {
+                  version = version,
+                  status  = valOf (Int.fromString status),
+                  reason  = reason,
                   headers = #headers response,
                   body    = #body response
               }
+          | _ =>  raise MalformedResponse (line)
 
     fun read (conn: socket) : t =
         let


### PR DESCRIPTION
The HTTP client module raises `MalformedResponse` when HTTP reason phrase contains spaces, for example: `HTTP/1.1 301 Moved Permanently`. 

`parseFirstLine` function split the first line of HTTP response with a space and expects a three-element list. This is wrong when reason phrase contains spaces.

My fix uses `Ponyo_String.splitN` instead of `Ponyo_String.split` to limit the length of the result list.

I noticed that I should use `Ponyo_String.splitN (line, " ", 2)`, not `Ponyo_String.splitN (line, " ", 3)`, if three-element list is needed. Confusing, but this works anyway.