### PR TITLE
Test String.splitN with trailing delimiter

### DIFF
--- a/src/String/String.sml
+++ b/src/String/String.sml
@@ -193,7 +193,7 @@ struct
 		    end
 
                 fun revAndOptAddCurrent (current: string, accum: string list) : string list =
-		    rev (if current = "" then accum else current :: accum)
+		    rev (current :: accum)
 
 	        fun doSplit (s: string, sl: string list) : string list =
 		    if n = List.length (sl) then revAndOptAddCurrent (s, sl)

--- a/test/Ponyo_String_Test.sml
+++ b/test/Ponyo_String_Test.sml
@@ -189,7 +189,8 @@ fun run () = [
         val s = String.splitN
     in [
         s ("foobarfoobarfoobar", "foobar", 1) = ["", "foobarfoobar"],
-        s ("foobar", "o", 1) = ["f", "obar"]
+        s ("foobar", "o", 1) = ["f", "obar"],
+        s ("www.google.com/", "/", 1) = ["www.google.com", ""]
     ] end
 ]
 


### PR DESCRIPTION
Noticed in #52 that `Ponyo.String.splitN ("www.google.com/", "/", 1)` doesn't produce the expected `["www.google.com", ""]`. Turns out there's some old logic explicitly disabling this case so I removed it. We'll see if that ends up breaking anything (tests aren't failing).