### PR TITLE
Remove redundant CRLF

### DIFF
--- a/src/Net/Http/Request.sml
+++ b/src/Net/Http/Request.sml
@@ -68,7 +68,7 @@ struct
 	    val headers = foldl (fn (a, b) => String.join ([a, b], "\r\n")) "" marshalled
 	    val body = #body request
 	in
-	    intro ^ headers ^ "\r\n\r\n" ^ body
+	    intro ^ headers ^ "\r\n" ^ body
         end
 
     fun write (socket: socket) (request: t) : unit =

--- a/src/Net/Http/Response.sml
+++ b/src/Net/Http/Response.sml
@@ -93,7 +93,7 @@ struct
                 else hd marshalled
             val body = #body response
         in
-            intro ^ headers ^ "\r\n\r\n" ^ body
+            intro ^ headers ^ "\r\n" ^ body
         end
 
     fun write (conn: socket) (response: t) : unit =


### PR DESCRIPTION
Header and message body are separated by two CRLFs. But since the header already ends with CRLF, "\r\n\r\n" here is redundant.
This can be a problem in an application where you must sign message body with hash algorithm etc.