### PR TITLE
Fix a small typo

### DIFF
--- a/site/static/app/templates/guides/learn-standardml/getting-started.jade
+++ b/site/static/app/templates/guides/learn-standardml/getting-started.jade
@@ -102,7 +102,7 @@ block body
                             Hello World!
                     p.
                         Poly/ML requires an un-called <code>main</code> function as
-                        an entry point. However, MLton simplies calls whatever is at
+                        an entry point. However, MLton simply calls whatever is at
                         the top-level and will not look for the <code>main</code>
                         function unless it is called.
                     p.


### PR DESCRIPTION
"Simplies" probably means "simply."