### PR TITLE
Fix encoding of character literals

### DIFF
--- a/site/static/app/templates/guides/learn-standardml/expressions-and-variables.jade
+++ b/site/static/app/templates/guides/learn-standardml/expressions-and-variables.jade
@@ -45,7 +45,7 @@ block body
                         li Integers (e.g. <code>1</code>, <code>~1</code>)
                         li Reals (e.g. <code>1.0</code>, <code>~1.0</code>)
                         li Strings (e.g. <code>"my string"</code>)
-                        li Characters (e.g. <code>'f'</code>, <code>'\n'</code>)
+                        li Characters (e.g. <code>#"f"</code>, <code>#"\n"</code>)
                         li Booleans <code>true</code> and <code>false</code>
                         li Tuples (e.g. <code>(1, 2)</code>, <code>(x, 4.0, (12, 1))</code>)
                         li Lists (e.g. <code>[1, 2]</code>, <code>[(1, 2), (3, 4)]</code>)

--- a/site/static/app/templates/guides/learn-standardml/getting-started.jade
+++ b/site/static/app/templates/guides/learn-standardml/getting-started.jade
@@ -102,7 +102,7 @@ block body
                             Hello World!
                     p.
                         Poly/ML requires an un-called <code>main</code> function as
-                        an entry point. However, MLton simplies calls whatever is at
+                        an entry point. However, MLton simply calls whatever is at
                         the top-level and will not look for the <code>main</code>
                         function unless it is called.
                     p.


### PR DESCRIPTION
In keeping with examples of SML literals provided within parentheses, perhaps, in order to maintain consistency, `'f'` should be replaced with `#"f"`, and ditto for `'\n'`.
