### PR TITLE
Pluralize the word 'parenthesis'

### DIFF
--- a/site/static/app/templates/guides/learn-standardml/expressions-and-variables.jade
+++ b/site/static/app/templates/guides/learn-standardml/expressions-and-variables.jade
@@ -54,7 +54,7 @@ block body
                         Some Standard ML implementations (including MLton, but not Poly/ML)
                         additionally have support for vector literals (e.g. <code>\#[1, 2, 3]</code>)
                         as part of Successor ML, informally agreed upon extensions to the standard.
-                    h4 Parenthesis, semi-colons and compound expressions
+                    h4 Parentheses, semi-colons and compound expressions
                     p.
                         Semi-colons are mostly optional, except for in compound expressions.
                         But semi-colons are often necessary to disambiguate the end of a function

--- a/site/static/app/templates/guides/learn-standardml/getting-started.jade
+++ b/site/static/app/templates/guides/learn-standardml/getting-started.jade
@@ -102,7 +102,7 @@ block body
                             Hello World!
                     p.
                         Poly/ML requires an un-called <code>main</code> function as
-                        an entry point. However, MLton simplies calls whatever is at
+                        an entry point. However, MLton simply calls whatever is at
                         the top-level and will not look for the <code>main</code>
                         function unless it is called.
                     p.


### PR DESCRIPTION
Plurarize the word _parenthesis_ to keep uniformity.