### PR TITLE
Fix build against recent OpenSSL versions.

### DIFF
--- a/lib/ssl.c
+++ b/lib/ssl.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <openssl/ssl.h>
+#include <openssl/err.h>
 
 #define DEBUG 0
 


### PR DESCRIPTION
This fixes an issue seen with OpenSSL 1.1.1f on Ubuntu 20.04. It looks like `ERR_get_error` was moved from `openssl/ssl.h` to `openssl/err.h`.

Build tested with both Poly/ML and MLton.
